### PR TITLE
Add clear source ~/.zshrc reminder after updates

### DIFF
--- a/install-remote.sh
+++ b/install-remote.sh
@@ -262,5 +262,5 @@ fi
 
 if [[ "$UNATTENDED" -eq 0 ]]; then
   echo ""
-  echo "Restart your shell or run 'source ~/.zshrc' to activate the plugin."
+  echo "🔔 IMPORTANT: Run 'source ~/.zshrc' or restart your terminal to activate the plugin."
 fi

--- a/install.sh
+++ b/install.sh
@@ -257,5 +257,5 @@ fi
 
 if [[ "$UNATTENDED" -eq 0 ]]; then
   echo ""
-  echo "Restart your shell or run 'source ~/.zshrc' to activate the plugin."
+  echo "🔔 IMPORTANT: Run 'source ~/.zshrc' or restart your terminal to activate the plugin."
 fi

--- a/zsh-nvm-pnpm-auto-switch.plugin.zsh
+++ b/zsh-nvm-pnpm-auto-switch.plugin.zsh
@@ -158,7 +158,8 @@ nvm_pnpm_auto_switch_update() {
     cd "$PLUGIN_DIR" && git pull
     if [[ $? -eq 0 ]]; then
       echo "✅ Plugin updated successfully using Git!"
-      echo "Run 'source ~/.zshrc' to apply changes."
+      echo ""
+      echo "🔔 IMPORTANT: Run 'source ~/.zshrc' or restart your terminal to apply changes."
       unset NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS
       return 0
     else
@@ -167,22 +168,30 @@ nvm_pnpm_auto_switch_update() {
   fi
   
   # Try curl or wget as fallback
+  local update_result=0
   if command -v curl &> /dev/null; then
     echo "📦 Using curl to download latest version..."
     curl -fsSL "$REPO_URL/raw/main/install-remote.sh" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
-    unset NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS
-    return $?
+    update_result=$?
   elif command -v wget &> /dev/null; then
     echo "📦 Using wget to download latest version..."
     wget -O- "$REPO_URL/raw/main/install-remote.sh" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
-    unset NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS
-    return $?
+    update_result=$?
   else
     echo "❌ Update failed: Neither git, curl, nor wget is available."
     echo "Please install one of these tools and try again."
     unset NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS
     return 1
   fi
+  
+  # If the update was successful, remind the user to source their .zshrc
+  if [[ $update_result -eq 0 ]]; then
+    echo ""
+    echo "🔔 IMPORTANT: Run 'source ~/.zshrc' or restart your terminal to apply changes."
+  fi
+  
+  unset NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS
+  return $update_result
 }
 
 # Function to uninstall the plugin


### PR DESCRIPTION
This PR improves the user experience by:

1. Adding more visible reminders for users to source their `.zshrc` file or restart their terminal after updates
2. Enhancing the update function to ensure this reminder is shown consistently
3. Making the reminder more prominent with an emoji and "IMPORTANT" label

These changes will help ensure users don't miss the crucial step of reloading their shell configuration after plugin updates, reducing confusion about why new changes might not be visible immediately.