### PR TITLE
Fix 404 error in update command

### DIFF
--- a/src/install-remote.sh
+++ b/src/install-remote.sh
@@ -37,8 +37,8 @@ if [[ "$UNATTENDED" -eq 0 ]]; then
 fi
 
 # Download the plugin files
-curl -fsSL "$REPO_URL/raw/main/src/$PLUGIN_NAME.plugin.zsh" -o "$PLUGIN_DIR/$PLUGIN_NAME.plugin.zsh"
-curl -fsSL "$REPO_URL/raw/main/src/workspace-config.zsh" -o "$PLUGIN_DIR/workspace-config.zsh"
+curl -fsSL "$REPO_URL/blob/main/src/$PLUGIN_NAME.plugin.zsh?raw=true" -o "$PLUGIN_DIR/$PLUGIN_NAME.plugin.zsh"
+curl -fsSL "$REPO_URL/blob/main/src/workspace-config.zsh?raw=true" -o "$PLUGIN_DIR/workspace-config.zsh"
 
 # Make the plugin executable
 chmod +x "$PLUGIN_DIR/$PLUGIN_NAME.plugin.zsh"
@@ -88,7 +88,7 @@ if [[ "$UNATTENDED" -eq 0 ]]; then
   fi
 
   echo "🔧 zsh-nvm-pnpm-auto-switch - Interactive Setup"
-  echo "========================================"
+  echo "======================================"
   echo ""
   
   # Ask for workspace directory

--- a/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
+++ b/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
@@ -171,11 +171,11 @@ nvm_pnpm_auto_switch_update() {
   local update_result=0
   if command -v curl &> /dev/null; then
     echo "📦 Using curl to download latest version..."
-    curl -fsSL "$REPO_URL/raw/main/install-remote.sh" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
+    curl -fsSL "$REPO_URL/blob/main/src/install-remote.sh?raw=true" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
     update_result=$?
   elif command -v wget &> /dev/null; then
     echo "📦 Using wget to download latest version..."
-    wget -O- "$REPO_URL/raw/main/install-remote.sh" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
+    wget -O- "$REPO_URL/blob/main/src/install-remote.sh?raw=true" | NVM_PNPM_AUTO_SWITCH_UPDATE_IN_PROGRESS=1 zsh
     update_result=$?
   else
     echo "❌ Update failed: Neither git, curl, nor wget is available."


### PR DESCRIPTION
This PR fixes the issue in the update command that was resulting in a 404 error.

The problem was in the URLs used to download the plugin files. GitHub's raw URLs should use the format:
`https://github.com/OWNER/REPO/blob/BRANCH/FILE?raw=true`

The changes update both the main plugin file and the install-remote.sh file to use this correct format when downloading files.

Changes:
- Updated URL format in `nvm_pnpm_auto_switch_update()` function to use `?raw=true` parameter
- Updated URL format in install-remote.sh to use the same format for consistency

This should resolve the 404 error seen when running the update command.