### PR TITLE
Fix Node.js version detection to use .nvmrc file

### DIFF
--- a/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
+++ b/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
@@ -39,14 +39,14 @@ nvm_pnpm_auto_switch() {
     local desired_node_version=""
     local packageManager=""
     
-    # Check for .npmrc file with Node.js version
-    if [[ -f ".npmrc" ]]; then
-      _nvm_pnpm_auto_switch_debug ".npmrc file found"
-      desired_node_version=$(grep "node-version" .npmrc | cut -d'=' -f2 | tr -d '[:space:]')
+    # Check for .nvmrc file with Node.js version
+    if [[ -f ".nvmrc" ]]; then
+      _nvm_pnpm_auto_switch_debug ".nvmrc file found"
+      desired_node_version=$(cat .nvmrc | tr -d '[:space:]')
       
       # If we found a desired Node.js version
       if [[ -n "$desired_node_version" ]]; then
-        _nvm_pnpm_auto_switch_debug "Found node-version=$desired_node_version in .npmrc"
+        _nvm_pnpm_auto_switch_debug "Found Node.js version: $desired_node_version in .nvmrc"
         
         # Add 'v' prefix if it doesn't have one
         if [[ ! "$desired_node_version" =~ ^v ]]; then
@@ -69,10 +69,10 @@ nvm_pnpm_auto_switch() {
           _nvm_pnpm_auto_switch_debug "Already using correct Node.js version: $current_node_version"
         fi
       else
-        _nvm_pnpm_auto_switch_debug "No node-version found in .npmrc"
+        _nvm_pnpm_auto_switch_debug "No Node.js version found in .nvmrc"
       fi
     else
-      _nvm_pnpm_auto_switch_debug "No .npmrc file found"
+      _nvm_pnpm_auto_switch_debug "No .nvmrc file found"
     fi
     
     # Get the package manager from package.json


### PR DESCRIPTION
This PR fixes an issue with Node.js version detection in the plugin.

## Issue
The plugin was incorrectly looking for the Node.js version in `.npmrc` files when it should be looking in `.nvmrc` files, which is the standard file used by nvm to specify Node.js versions.

## Changes
- Updated the Node.js version detection logic to look for and read `.nvmrc` files instead of `.npmrc` files
- Simplified the version detection by using `cat .nvmrc` to read the entire file content
- Updated the debug messages to be more accurate

## Testing
The changes have been tested in a Node.js project with an `.nvmrc` file, and the plugin now correctly detects and switches to the Node.js version specified in the `.nvmrc` file.

Before this change, when switching to a directory containing `.nvmrc`, the debug output would show:
```
[zsh-nvm-pnpm-auto-switch] Node.js project detected
[zsh-nvm-pnpm-auto-switch] No .npmrc file found
```

After this change, the debug output shows:
```
[zsh-nvm-pnpm-auto-switch] Node.js project detected
[zsh-nvm-pnpm-auto-switch] .nvmrc file found
[zsh-nvm-pnpm-auto-switch] Found Node.js version: XXX in .nvmrc
```

And the plugin will correctly switch to the Node.js version specified in the `.nvmrc` file.