### PR TITLE
Improve logging to show when already using correct versions

### DIFF
--- a/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
+++ b/src/zsh-nvm-pnpm-auto-switch.plugin.zsh
@@ -67,6 +67,10 @@ nvm_pnpm_auto_switch() {
           nvm use "$desired_node_version" &>/dev/null
         else
           _nvm_pnpm_auto_switch_debug "Already using correct Node.js version: $current_node_version"
+          # Show message to user if not in debug mode
+          if [[ "$NVM_PNPM_AUTO_SWITCH_DEBUG" != "1" ]]; then
+            echo "👍 Using correct Node.js version: $current_node_version"
+          fi
         fi
       else
         _nvm_pnpm_auto_switch_debug "No Node.js version found in .nvmrc"
@@ -103,6 +107,10 @@ nvm_pnpm_auto_switch() {
           corepack prepare pnpm@$desired_pnpm_version --activate &>/dev/null
         else
           _nvm_pnpm_auto_switch_debug "Already using correct pnpm version: $current_pnpm_version"
+          # Show message to user if not in debug mode
+          if [[ "$NVM_PNPM_AUTO_SWITCH_DEBUG" != "1" ]]; then
+            echo "👍 Using correct pnpm version: $current_pnpm_version"
+          fi
         fi
       else
         _nvm_pnpm_auto_switch_debug "Package manager is not pnpm: $packageManager"


### PR DESCRIPTION
This PR improves the plugin logging to provide better feedback when the current Node.js and pnpm versions are already correct.

## Changes
- Added user-friendly messages that display when the plugin detects that the current Node.js version matches the desired version in .nvmrc
- Added user-friendly messages that display when the current pnpm version matches the desired version in package.json
- These messages only appear in non-debug mode (when `NVM_PNPM_AUTO_SWITCH_DEBUG` is not set to 1)
- Added a 👍 emoji to make it clear that everything is already correct

## Example
Before this change, when a user entered a directory where the correct Node.js and pnpm versions were already active, no message was displayed unless debug mode was enabled. This could be confusing because users wouldn't know if the plugin was working properly.

With this change, users will now see something like:
```
👍 Using correct Node.js version: v16.14.0
👍 Using correct pnpm version: 7.9.0
```

This provides better feedback and reassurance that the tool is working as expected, even when no version switching is needed.

## Testing
The changes have been tested in different scenarios:
1. When entering a directory where Node.js and pnpm versions need to be switched
2. When entering a directory where the correct versions are already active
3. With debug mode enabled and disabled

All scenarios work as expected, with appropriate messages displayed to the user.